### PR TITLE
Update any.h to address the thread safety issues

### DIFF
--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -141,7 +141,7 @@ SMALL_POLICY(bool);
 
 /// This function will return a different policy for each type.
 template<typename T>
-base_any_policy* get_policy()
+static base_any_policy* get_policy()
 {
     static typename choose_policy<T>::type policy;
     return &policy;


### PR DESCRIPTION
Even with C++11, any.h still crashes in some circumstances. Don't know why, but the solution provided [here](https://github.com/mariusmuja/flann/issues/347#issuecomment-321654876) do fix the problem.

I have encounter this issue on macOS Mojave with `FLANN` 1.9.1 and `PCL` 1.9.1. The compiler is Clang 10.0.0